### PR TITLE
Ensure single server config manager instance

### DIFF
--- a/src/infrastructure/PAL/tun_server/server_worker_factory_darwin.go
+++ b/src/infrastructure/PAL/tun_server/server_worker_factory_darwin.go
@@ -4,16 +4,19 @@ import (
 	"context"
 	"io"
 	"tungo/application"
+	"tungo/infrastructure/PAL/server_configuration"
 	"tungo/infrastructure/settings"
 )
 
 type ServerWorkerFactory struct {
-	settings settings.Settings
+	settings             settings.Settings
+	configurationManager server_configuration.ServerConfigurationManager
 }
 
-func NewServerWorkerFactory(settings settings.Settings) application.ServerWorkerFactory {
+func NewServerWorkerFactory(settings settings.Settings, manager server_configuration.ServerConfigurationManager) application.ServerWorkerFactory {
 	return &ServerWorkerFactory{
-		settings: settings,
+		settings:             settings,
+		configurationManager: manager,
 	}
 }
 

--- a/src/infrastructure/PAL/tun_server/server_worker_factory_linux_test.go
+++ b/src/infrastructure/PAL/tun_server/server_worker_factory_linux_test.go
@@ -99,7 +99,7 @@ func (f *ServerWorkerFactoryMockLoggerFactory) newLogger() application.Logger {
 // --- tests ---
 func TestCreateWorker_UnsupportedProtocol(t *testing.T) {
 	s := settings.Settings{Protocol: 42}
-	factory := NewServerWorkerFactory(s)
+	factory := NewServerWorkerFactory(s, nil)
 	_, err := factory.CreateWorker(context.Background(), nopReadWriteCloser{})
 	if err == nil {
 		t.Fatal("expected unsupported-protocol error")
@@ -116,7 +116,7 @@ func TestCreateWorker_TCP_SocketError(t *testing.T) {
 	tcpF := &ServerWorkerFactoryMockTcpListenerFactory{}
 	udpF := &ServerWorkerFactoryMockUdpListenerFactory{}
 	logF := &ServerWorkerFactoryMockLoggerFactory{}
-	factory := NewTestServerWorkerFactory(s, sockF, tcpF, udpF, logF)
+	factory := NewTestServerWorkerFactory(s, sockF, tcpF, udpF, logF, nil)
 
 	_, err := factory.CreateWorker(context.Background(), nopReadWriteCloser{})
 	if err == nil || err.Error() != "bad socket" {
@@ -134,7 +134,7 @@ func TestCreateWorker_TCP_ListenerError(t *testing.T) {
 	tcpF := &ServerWorkerFactoryMockTcpListenerFactory{Err: errors.New("listen fail")}
 	udpF := &ServerWorkerFactoryMockUdpListenerFactory{}
 	logF := &ServerWorkerFactoryMockLoggerFactory{}
-	factory := NewTestServerWorkerFactory(s, sockF, tcpF, udpF, logF)
+	factory := NewTestServerWorkerFactory(s, sockF, tcpF, udpF, logF, nil)
 
 	_, err := factory.CreateWorker(context.Background(), nopReadWriteCloser{})
 	if err == nil || err.Error() != "failed to listen TCP: listen fail" {
@@ -152,7 +152,7 @@ func TestCreateWorker_TCP_Success(t *testing.T) {
 	tcpF := &ServerWorkerFactoryMockTcpListenerFactory{}
 	udpF := &ServerWorkerFactoryMockUdpListenerFactory{}
 	logF := &ServerWorkerFactoryMockLoggerFactory{}
-	factory := NewTestServerWorkerFactory(s, sockF, tcpF, udpF, logF)
+	factory := NewTestServerWorkerFactory(s, sockF, tcpF, udpF, logF, nil)
 
 	w, err := factory.CreateWorker(context.Background(), nopReadWriteCloser{})
 	if err != nil {
@@ -178,7 +178,7 @@ func TestCreateWorker_UDP_Success(t *testing.T) {
 	tcpF := &ServerWorkerFactoryMockTcpListenerFactory{}
 	udpF := &ServerWorkerFactoryMockUdpListenerFactory{}
 	logF := &ServerWorkerFactoryMockLoggerFactory{}
-	factory := NewTestServerWorkerFactory(s, sockF, tcpF, udpF, logF)
+	factory := NewTestServerWorkerFactory(s, sockF, tcpF, udpF, logF, nil)
 
 	w, err := factory.CreateWorker(context.Background(), nopReadWriteCloser{})
 	if err != nil {

--- a/src/infrastructure/PAL/tun_server/server_worker_factory_windows.go
+++ b/src/infrastructure/PAL/tun_server/server_worker_factory_windows.go
@@ -4,16 +4,19 @@ import (
 	"context"
 	"io"
 	"tungo/application"
+	"tungo/infrastructure/PAL/server_configuration"
 	"tungo/infrastructure/settings"
 )
 
 type ServerWorkerFactory struct {
-	settings settings.Settings
+	settings             settings.Settings
+	configurationManager server_configuration.ServerConfigurationManager
 }
 
-func NewServerWorkerFactory(settings settings.Settings) application.ServerWorkerFactory {
+func NewServerWorkerFactory(settings settings.Settings, manager server_configuration.ServerConfigurationManager) application.ServerWorkerFactory {
 	return &ServerWorkerFactory{
-		settings: settings,
+		settings:             settings,
+		configurationManager: manager,
 	}
 }
 

--- a/src/main.go
+++ b/src/main.go
@@ -100,6 +100,7 @@ func startServer(appCtx context.Context) {
 		*conf,
 		server_configuration.NewEd25519KeyManager(conf, configurationManager),
 		server_configuration.NewDefaultSessionLifetimeManager(conf, configurationManager),
+		configurationManager,
 	)
 
 	runner := server.NewRunner(deps)

--- a/src/presentation/runners/server/dependencies.go
+++ b/src/presentation/runners/server/dependencies.go
@@ -10,6 +10,7 @@ type AppDependencies interface {
 	TunManager() application.ServerTunManager
 	KeyManager() server_configuration.KeyManager
 	SessionLifetimeManager() server_configuration.SessionLifetimeManager
+	ConfigurationManager() server_configuration.ServerConfigurationManager
 }
 
 type Dependencies struct {
@@ -17,6 +18,7 @@ type Dependencies struct {
 	tunManager             application.ServerTunManager
 	keyManager             server_configuration.KeyManager
 	sessionLifetimeManager server_configuration.SessionLifetimeManager
+	configurationManager   server_configuration.ServerConfigurationManager
 }
 
 func NewDependencies(
@@ -24,12 +26,14 @@ func NewDependencies(
 	configuration server_configuration.Configuration,
 	keyManager server_configuration.KeyManager,
 	sessionLifetimeManager server_configuration.SessionLifetimeManager,
+	configurationManager server_configuration.ServerConfigurationManager,
 ) AppDependencies {
 	return &Dependencies{
 		configuration:          configuration,
 		tunManager:             tunManager,
 		keyManager:             keyManager,
 		sessionLifetimeManager: sessionLifetimeManager,
+		configurationManager:   configurationManager,
 	}
 }
 
@@ -47,4 +51,8 @@ func (s Dependencies) KeyManager() server_configuration.KeyManager {
 
 func (s Dependencies) SessionLifetimeManager() server_configuration.SessionLifetimeManager {
 	return s.sessionLifetimeManager
+}
+
+func (s Dependencies) ConfigurationManager() server_configuration.ServerConfigurationManager {
+	return s.configurationManager
 }

--- a/src/presentation/runners/server/dependencies_test.go
+++ b/src/presentation/runners/server/dependencies_test.go
@@ -46,7 +46,7 @@ func TestNewDependenciesAndAccessors(t *testing.T) {
 	km := &dummyKeyMgr{}
 	sm := &dummySessionLifetimeMgr{}
 
-	deps := NewDependencies(tm, cfg, km, sm)
+	deps := NewDependencies(tm, cfg, km, sm, nil)
 
 	gotCfg := deps.Configuration()
 	if gotCfg.EnableTCP != cfg.EnableTCP {
@@ -89,5 +89,9 @@ func TestNewDependenciesAndAccessors(t *testing.T) {
 	}
 	if !sm.called {
 		t.Error("SessionLifetimeManager().PrepareSessionLifetime() was not invoked on underlying manager")
+	}
+
+	if deps.ConfigurationManager() != nil {
+		t.Error("expected nil ConfigurationManager")
 	}
 }

--- a/src/presentation/runners/server/runner.go
+++ b/src/presentation/runners/server/runner.go
@@ -69,7 +69,7 @@ func (r *Runner) Run(ctx context.Context) {
 }
 
 func (r *Runner) route(ctx context.Context, settings settings.Settings) error {
-	workerFactory := tun_server.NewServerWorkerFactory(settings)
+	workerFactory := tun_server.NewServerWorkerFactory(settings, r.deps.ConfigurationManager())
 	routerFactory := factory.NewServerRouterFactory()
 
 	tun, tunErr := r.deps.TunManager().CreateTunDevice(settings)


### PR DESCRIPTION
## Summary
- create server configuration manager only at startup
- pass configuration manager through dependencies and factories
- update transport handlers to use provided manager
- fix tests accordingly

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6866d4ae23fc8333aba9ce3c17aff8da