### PR TITLE
Increase coverage of server transport handlers

### DIFF
--- a/src/infrastructure/PAL/tun_server/server_worker_factory_linux.go
+++ b/src/infrastructure/PAL/tun_server/server_worker_factory_linux.go
@@ -109,6 +109,7 @@ func (s *ServerWorkerFactory) createTCPWorker(ctx context.Context, tun io.ReadWr
 		sessionManager,
 		s.loggerFactory.newLogger(),
 		NewHandshakeFactory(*conf),
+		chacha20.NewTcpSessionBuilder(),
 	)
 	return tcp_chacha20.NewTcpTunWorker(th, tr), nil
 }
@@ -151,6 +152,7 @@ func (s *ServerWorkerFactory) createUDPWorker(ctx context.Context, tun io.ReadWr
 		ttlConcurrentSessionManager,
 		s.loggerFactory.newLogger(),
 		NewHandshakeFactory(*conf),
+		chacha20.NewUdpSessionBuilder(),
 	)
 	return udp_chacha20.NewUdpTunWorker(th, tr), nil
 }


### PR DESCRIPTION
## Summary
- refactor server TCP and UDP transport handlers to accept a cryptography service builder
- update server worker factory to supply the new builders
- expand TCP transport handler tests
- expand UDP transport handler tests

## Testing
- `go test ./infrastructure/routing/server_routing/routing/tcp_chacha20 -cover`
- `go test ./infrastructure/routing/server_routing/routing/udp_chacha20 -cover`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_686828b8950c8333b535bf955a2702c4