### PR TITLE
Add HMAC based handshake obfuscation

### DIFF
--- a/src/infrastructure/cryptography/chacha20/handshake/server_handshake.go
+++ b/src/infrastructure/cryptography/chacha20/handshake/server_handshake.go
@@ -2,36 +2,90 @@ package handshake
 
 import (
 	"crypto/ed25519"
+	"crypto/hmac"
+	"crypto/sha256"
 	"fmt"
 	"io"
 	"tungo/application"
 )
 
 type ServerHandshake struct {
-	conn application.ConnectionAdapter
+	conn      application.ConnectionAdapter
+	sharedKey []byte
 }
 
-func NewServerHandshake(conn application.ConnectionAdapter) ServerHandshake {
+func NewServerHandshake(conn application.ConnectionAdapter, sharedKey []byte) ServerHandshake {
 	return ServerHandshake{
-		conn: conn,
+		conn:      conn,
+		sharedKey: sharedKey,
 	}
 }
 
 func (h *ServerHandshake) ReceiveClientHello() (ClientHello, error) {
-	buf := make([]byte, MaxClientHelloSizeBytes)
-	_, readErr := h.conn.Read(buf)
-	if readErr != nil {
-		return ClientHello{}, readErr
+	var first [1]byte
+	if _, err := io.ReadFull(h.conn, first[:]); err != nil {
+		return ClientHello{}, err
 	}
 
-	//Read client hello
-	var clientHello ClientHello
-	unmarshalErr := clientHello.UnmarshalBinary(buf)
-	if unmarshalErr != nil {
-		return ClientHello{}, unmarshalErr
+	// plain hello starts with ip version
+	if first[0] == 4 || first[0] == 6 {
+		var hdr [1]byte
+		if _, err := io.ReadFull(h.conn, hdr[:]); err != nil {
+			return ClientHello{}, err
+		}
+		ipLen := int(hdr[0])
+		rest := make([]byte, ipLen+curvePublicKeyLength+curvePublicKeyLength+nonceLength)
+		if _, err := io.ReadFull(h.conn, rest); err != nil {
+			return ClientHello{}, err
+		}
+
+		data := append([]byte{first[0], hdr[0]}, rest...)
+		var hello ClientHello
+		if err := hello.UnmarshalBinary(data); err != nil {
+			return ClientHello{}, err
+		}
+		return hello, nil
 	}
 
-	return clientHello, nil
+	// obfuscated hello
+	padLenBuf := make([]byte, 1)
+	if _, err := io.ReadFull(h.conn, padLenBuf); err != nil {
+		return ClientHello{}, err
+	}
+	padLen := int(padLenBuf[0])
+	initial := padLen + minClientHelloSizeBytes + hmacLength
+	buf := make([]byte, initial)
+	if _, err := io.ReadFull(h.conn, buf); err != nil {
+		return ClientHello{}, err
+	}
+
+	ipLen := int(buf[padLen+1])
+	helloLen := lengthHeaderLength + ipLen + curvePublicKeyLength + curvePublicKeyLength + nonceLength
+	total := padLen + helloLen + hmacLength
+	if total > initial {
+		extra := make([]byte, total-initial)
+		if _, err := io.ReadFull(h.conn, extra); err != nil {
+			return ClientHello{}, err
+		}
+		buf = append(buf, extra...)
+	}
+
+	padding := buf[:padLen]
+	helloBytes := buf[padLen : padLen+helloLen]
+	receivedMac := buf[padLen+helloLen : total]
+
+	mac := hmac.New(sha256.New, h.sharedKey)
+	mac.Write(padding)
+	mac.Write(helloBytes)
+	if !hmac.Equal(mac.Sum(nil), receivedMac) {
+		return ClientHello{}, fmt.Errorf("invalid hmac")
+	}
+
+	var hello ClientHello
+	if err := hello.UnmarshalBinary(helloBytes); err != nil {
+		return ClientHello{}, err
+	}
+	return hello, nil
 }
 
 func (h *ServerHandshake) SendServerHello(


### PR DESCRIPTION
## Summary
- support obfuscated `ClientHello` using HMAC and random padding
- allow server to parse legacy and obfuscated hellos
- use Ed25519 public key as shared HMAC key
- test new handshake behaviour

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_686d62ce0fe083339935859674b8a001