### PR TITLE
Fix UDP dual-stack endpoint selection

### DIFF
--- a/src/infrastructure/tunnel/sessionplane/client_factory/connection_factory.go
+++ b/src/infrastructure/tunnel/sessionplane/client_factory/connection_factory.go
@@ -172,9 +172,16 @@ func (f *ConnectionFactory) dialWithFallback(
 		return nil, preferredErr
 	}
 	// UDP dial only creates a connected socket; it does not prove endpoint reachability.
-	// Use the preferred address directly instead of treating an IPv6 probe as success.
+	// Prefer the default address, but still fall back on immediate local dial errors.
 	if s.Protocol == settings.UDP {
-		return dialFn(ctx, preferredAP)
+		transport, dialErr := dialFn(ctx, preferredAP)
+		if dialErr == nil {
+			return transport, nil
+		}
+		if ipv6AP, ipv6Err := resolveIPv6AddrPort(ctx, s); ipv6Err == nil && ipv6AP != preferredAP {
+			return dialFn(ctx, ipv6AP)
+		}
+		return nil, dialErr
 	}
 
 	ipv6AP, ipv6Err := resolveIPv6AddrPort(ctx, s)

--- a/src/infrastructure/tunnel/sessionplane/client_factory/connection_factory.go
+++ b/src/infrastructure/tunnel/sessionplane/client_factory/connection_factory.go
@@ -171,6 +171,11 @@ func (f *ConnectionFactory) dialWithFallback(
 		}
 		return nil, preferredErr
 	}
+	// UDP dial only creates a connected socket; it does not prove endpoint reachability.
+	// Use the preferred address directly instead of treating an IPv6 probe as success.
+	if s.Protocol == settings.UDP {
+		return dialFn(ctx, preferredAP)
+	}
 
 	ipv6AP, ipv6Err := resolveIPv6AddrPort(ctx, s)
 	if ipv6Err != nil {

--- a/src/infrastructure/tunnel/sessionplane/client_factory/connection_factory_test.go
+++ b/src/infrastructure/tunnel/sessionplane/client_factory/connection_factory_test.go
@@ -1056,6 +1056,38 @@ func TestDialWithFallback_UDP_DualStackFallsBackToIPv6WhenPreferredIPv4DialFails
 	}
 }
 
+func TestDialWithFallback_UDP_ReturnsPreferredDialErrorWhenIPv6FallbackUnavailable(t *testing.T) {
+	t.Parallel()
+	f := &ConnectionFactory{}
+
+	s := settings.Settings{
+		Addressing: settings.Addressing{
+			Server: mustHost("198.51.100.10"),
+			Port:   9090,
+		},
+		Protocol: settings.UDP,
+	}
+
+	wantErr := errors.New("IPv4 unavailable")
+	var calls int
+	got, err := f.dialWithFallback(context.Background(), s, func(_ context.Context, ap netip.AddrPort) (connection.Transport, error) {
+		calls++
+		if !ap.Addr().Unmap().Is4() {
+			t.Fatalf("expected only IPv4 attempt, got %v", ap)
+		}
+		return nil, wantErr
+	})
+	if got != nil {
+		t.Fatalf("expected nil transport, got %T", got)
+	}
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("expected preferred dial error %v, got %v", wantErr, err)
+	}
+	if calls != 1 {
+		t.Fatalf("expected one UDP dial attempt, got %d", calls)
+	}
+}
+
 func TestDialWithFallback_IPv6Only_DialsOnce(t *testing.T) {
 	t.Parallel()
 	f := &ConnectionFactory{}

--- a/src/infrastructure/tunnel/sessionplane/client_factory/connection_factory_test.go
+++ b/src/infrastructure/tunnel/sessionplane/client_factory/connection_factory_test.go
@@ -982,6 +982,42 @@ func TestDialWithFallback_IPv6Success(t *testing.T) {
 	}
 }
 
+func TestDialWithFallback_UDP_DualStackUsesPreferredIPv4(t *testing.T) {
+	t.Parallel()
+	f := &ConnectionFactory{}
+	tr := &cfUnitTransport{}
+
+	s := settings.Settings{
+		Addressing: settings.Addressing{
+			Server: mustHost("198.51.100.10").WithIPv6(netip.MustParseAddr("2001:db8::10")),
+			Port:   9090,
+		},
+		Protocol: settings.UDP,
+	}
+
+	var (
+		calls      int
+		dialedAddr netip.AddrPort
+	)
+	got, err := f.dialWithFallback(context.Background(), s, func(_ context.Context, ap netip.AddrPort) (connection.Transport, error) {
+		calls++
+		dialedAddr = ap
+		return tr, nil
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != tr {
+		t.Fatal("expected transport from UDP dial")
+	}
+	if calls != 1 {
+		t.Fatalf("expected one UDP dial attempt, got %d", calls)
+	}
+	if !dialedAddr.Addr().Unmap().Is4() {
+		t.Fatalf("expected UDP to prefer IPv4, got %v", dialedAddr)
+	}
+}
+
 func TestDialWithFallback_IPv6Only_DialsOnce(t *testing.T) {
 	t.Parallel()
 	f := &ConnectionFactory{}

--- a/src/infrastructure/tunnel/sessionplane/client_factory/connection_factory_test.go
+++ b/src/infrastructure/tunnel/sessionplane/client_factory/connection_factory_test.go
@@ -1018,6 +1018,44 @@ func TestDialWithFallback_UDP_DualStackUsesPreferredIPv4(t *testing.T) {
 	}
 }
 
+func TestDialWithFallback_UDP_DualStackFallsBackToIPv6WhenPreferredIPv4DialFails(t *testing.T) {
+	t.Parallel()
+	f := &ConnectionFactory{}
+	tr := &cfUnitTransport{}
+
+	s := settings.Settings{
+		Addressing: settings.Addressing{
+			Server: mustHost("198.51.100.10").WithIPv6(netip.MustParseAddr("2001:db8::10")),
+			Port:   9090,
+		},
+		Protocol: settings.UDP,
+	}
+
+	var dialed []netip.AddrPort
+	got, err := f.dialWithFallback(context.Background(), s, func(_ context.Context, ap netip.AddrPort) (connection.Transport, error) {
+		dialed = append(dialed, ap)
+		if ap.Addr().Unmap().Is4() {
+			return nil, errors.New("IPv4 unavailable")
+		}
+		return tr, nil
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != tr {
+		t.Fatal("expected transport from IPv6 fallback")
+	}
+	if len(dialed) != 2 {
+		t.Fatalf("expected IPv4 then IPv6 attempts, got %v", dialed)
+	}
+	if !dialed[0].Addr().Unmap().Is4() {
+		t.Fatalf("expected first UDP attempt to use IPv4, got %v", dialed[0])
+	}
+	if !dialed[1].Addr().Is6() {
+		t.Fatalf("expected second UDP attempt to use IPv6, got %v", dialed[1])
+	}
+}
+
 func TestDialWithFallback_IPv6Only_DialsOnce(t *testing.T) {
 	t.Parallel()
 	f := &ConnectionFactory{}


### PR DESCRIPTION
## Summary
- Prefer the resolved/default endpoint for UDP instead of treating an IPv6 UDP dial probe as reachability proof.
- Add coverage for UDP dual-stack endpoint selection.

## Root Cause
UDP dial creates a connected socket but does not verify that the peer can respond. In dual-stack configs the previous IPv6-first probe could succeed at dial time, then hang during handshake on bridged Windows/UTM networks.

## Validation
- go test ./infrastructure/tunnel/sessionplane/client_factory
- go test ./...
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved UDP connection handling to use the preferred address directly, avoiding unnecessary IPv6 probing and fallback retries.
  * Clarified behavior so UDP connections are treated as connected sockets without assuming endpoint reachability from probe results.

* **Tests**
  * Added coverage to verify UDP dialing prefers IPv4 in dual-stack setups and makes only one dial attempt.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->