### PR TITLE
Update CI action versions

### DIFF
--- a/.github/workflows/docusaurus.yml
+++ b/.github/workflows/docusaurus.yml
@@ -34,6 +34,7 @@ jobs:
         uses: actions/upload-pages-artifact@v5.0.0
         with:
           path: docs/TunGo/build
+          include-hidden-files: true
 
   deploy:
     name: Deploy to GitHub Pages

--- a/.github/workflows/docusaurus.yml
+++ b/.github/workflows/docusaurus.yml
@@ -15,6 +15,7 @@ jobs:
       - uses: actions/checkout@v7.0.0
         with:
           fetch-depth: 0
+          persist-credentials: false
       - uses: actions/setup-node@v6.4.0
         with:
           node-version: 22

--- a/.github/workflows/docusaurus.yml
+++ b/.github/workflows/docusaurus.yml
@@ -12,10 +12,10 @@ jobs:
     name: Build Docusaurus
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7.0.0
         with:
           fetch-depth: 0
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6.4.0
         with:
           node-version: 22
           cache: npm
@@ -31,7 +31,7 @@ jobs:
           npm run build
 
       - name: Upload Build Artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5.0.0
         with:
           path: docs/TunGo/build
 
@@ -51,4 +51,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5.0.0

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,13 +20,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get repository code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7.0.0
         with:
           fetch-depth: 0
           submodules: 'recursive'
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6.5.0
         with:
           go-version: ${{ env.GO_VERSION }}
 
@@ -44,7 +44,7 @@ jobs:
             go test -coverprofile=coverage.txt ./...
 
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v7.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: src/coverage.txt
@@ -69,13 +69,13 @@ jobs:
             goarch: arm64
     steps:
       - name: Get repository code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7.0.0
         with:
           fetch-depth: 0
           submodules: 'recursive'
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6.5.0
         with:
           go-version: ${{ env.GO_VERSION }}
 
@@ -90,26 +90,26 @@ jobs:
     needs: [run-tests, cross-compile-tests]
     if: github.event_name == 'push' # Prevents this job from running in PR. It will only run on push to main.
     outputs:
-      semver: ${{ steps.gitversion.outputs.semver }}
+      semver: ${{ steps.gitversion.outputs.semVer }}
     steps:
       - name: Get repository code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7.0.0
         with:
           fetch-depth: 0
           submodules: 'recursive'
 
       - name: Install GitVersion
-        uses: gittools/actions/gitversion/setup@v0.9
+        uses: gittools/actions/gitversion/setup@v4.5.0
         with:
-          versionSpec: '5.x'
+          versionSpec: '6.8.x'
 
       - name: Generate Version
         id: gitversion
-        uses: gittools/actions/gitversion/execute@v0.9
+        uses: gittools/actions/gitversion/execute@v4.5.0
 
       - name: Tag and Push Version
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          git tag $(echo ${{ steps.gitversion.outputs.semver }})
-          git push origin $(echo ${{ steps.gitversion.outputs.semver }})
+          git tag $(echo ${{ steps.gitversion.outputs.semVer }})
+          git push origin $(echo ${{ steps.gitversion.outputs.semVer }})

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
       tag_name: ${{ steps.get_tag.outputs.tag_name }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7.0.0
         with:
           fetch-depth: 0
 
@@ -29,10 +29,10 @@ jobs:
      VER: ${{ needs.version-and-tag.outputs.tag_name }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7.0.0
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6.5.0
         with:
           go-version: ${{ env.GO_VERSION }}
           cache: true
@@ -48,7 +48,7 @@ jobs:
             -o ../tungo-linux-amd64
 
       - name: Upload Linux binary artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: tungo-linux-amd64
           path: tungo-linux-amd64
@@ -64,7 +64,7 @@ jobs:
             -o ../tungo-linux-arm64
 
       - name: Upload Linux arm64 artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: tungo-linux-arm64
           path: tungo-linux-arm64
@@ -76,10 +76,10 @@ jobs:
      VER: ${{ needs.version-and-tag.outputs.tag_name }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7.0.0
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6.5.0
         with:
           go-version: ${{ env.GO_VERSION }}
           cache: true
@@ -95,7 +95,7 @@ jobs:
             -o ../tungo-darwin-amd64
   
       - name: Upload darwin-amd64
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: tungo-darwin-amd64
           path: tungo-darwin-amd64
@@ -111,7 +111,7 @@ jobs:
             -o ../tungo-darwin-arm64
   
       - name: Upload darwin-arm64
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: tungo-darwin-arm64
           path: tungo-darwin-arm64
@@ -123,10 +123,10 @@ jobs:
      VER: ${{ needs.version-and-tag.outputs.tag_name }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7.0.0
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6.5.0
         with:
           go-version: ${{ env.GO_VERSION }}
           cache: true
@@ -252,7 +252,7 @@ jobs:
           ISCC.exe setup-x64.iss
 
       - name: Upload Windows x64 installer artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: tungo-windows-amd64
           path: Output/tungo-windows-amd64.exe
@@ -343,7 +343,7 @@ jobs:
           ISCC.exe setup-arm64.iss
 
       - name: Upload Windows arm64 installer artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: tungo-windows-arm64
           path: Output/tungo-windows-arm64.exe
@@ -353,7 +353,7 @@ jobs:
     needs: version-and-tag
     steps:
       - name: Get repository code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7.0.0
         with:
           fetch-depth: 0
           submodules: 'recursive'
@@ -363,7 +363,7 @@ jobs:
         run: echo "VERSION=$(git describe --tags --abbrev=0)" >> $GITHUB_ENV
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6.5.0
         with:
           go-version: ${{ env.GO_VERSION }}
           cache: true
@@ -374,13 +374,13 @@ jobs:
           go mod tidy
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4.2.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4.1.0
 
       - name: Build and Tag Docker Image
         env:
@@ -400,23 +400,23 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build-linux, build-macos, build-windows, version-and-tag]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7.0.0
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8.0.1
         with: { name: tungo-linux-amd64, path: artifacts }
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8.0.1
         with: { name: tungo-linux-arm64, path: artifacts }
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8.0.1
         with: { name: tungo-darwin-amd64, path: artifacts }
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8.0.1
         with: { name: tungo-darwin-arm64, path: artifacts }
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8.0.1
         with: { name: tungo-windows-amd64, path: artifacts }
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8.0.1
         with: { name: tungo-windows-arm64, path: artifacts }
 
       - name: Publish GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3.0.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -438,7 +438,7 @@ jobs:
     needs: [create-release, version-and-tag]
     steps:
       - name: Checkout homebrew-tungo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7.0.0
         with:
           repository: NLipatov/homebrew-tungo
           token: ${{ secrets.HOMEBREW_TAP_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -401,6 +401,8 @@ jobs:
     needs: [build-linux, build-macos, build-windows, version-and-tag]
     steps:
       - uses: actions/checkout@v7.0.0
+        with:
+          persist-credentials: false
 
       - uses: actions/download-artifact@v8.0.1
         with: { name: tungo-linux-amd64, path: artifacts }


### PR DESCRIPTION
## Summary
- Update GitHub Actions used by CI, docs deployment, and release workflows to current release tags.
- Upgrade GitTools GitVersion actions from v0.9 to v4.5.0 and GitVersion.Tool from 5.x to 6.8.x.
- Update GitVersion output references from semver to semVer for the newer action output casing.

## Root Cause
The old GitTools action emits deprecated ::set-env and ::add-path workflow commands, which are now rejected by GitHub Actions runners.

## Validation
- yq e '.' .github/workflows/main.yml
- yq e '.' .github/workflows/docusaurus.yml
- yq e '.' .github/workflows/release.yml
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the site build, testing, and release workflows to newer automation versions for more reliable deployments and releases.
  * Improved artifact handling during Pages publishing and release packaging, helping ensure generated files are transferred correctly.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->