### PR TITLE
Fix CLI usage commands

### DIFF
--- a/src/presentation/ui/cli/configurator.go
+++ b/src/presentation/ui/cli/configurator.go
@@ -53,9 +53,13 @@ func (c *Configurator) trimArgs(args []string) []string {
 }
 
 func (c *Configurator) printUsage() {
-	fmt.Printf(`Usage: %s <mode>
-Modes:
-  %s  - Server
-  %s  - Client
-`, app.Name, ServerMode, ClientMode)
+	fmt.Printf(`Usage:
+  %s <command>
+
+Commands:
+  %-7s  Start server
+  %-7s  Start client
+  %-7s  Generate client configuration
+  %-7s  Show version
+`, app.Name, ServerMode, ClientMode, ServerConfGenMode, Version)
 }

--- a/src/presentation/ui/cli/configurator_test.go
+++ b/src/presentation/ui/cli/configurator_test.go
@@ -66,3 +66,20 @@ func TestConfigureErrors(t *testing.T) {
 		t.Fatalf("expected usage banner for invalid args")
 	}
 }
+
+func TestUsageListsSupportedCommands(t *testing.T) {
+	out, _, _ := run(nil)
+	for _, want := range []string{
+		"Usage:",
+		"  tungo <command>",
+		"Commands:",
+		"  s        Start server",
+		"  c        Start client",
+		"  s gen    Generate client configuration",
+		"  version  Show version",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("expected usage to contain %q, got %q", want, out)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Update the CLI usage banner to list all currently supported commands.
- Add a focused test that keeps the usage output in sync with supported CLI commands.

## Why

The CLI already supports `s gen` and `version`, but the usage banner still described only the old `s` and `c` modes. This made the built-in command help incomplete.

## Validation

- `go test ./presentation/ui/cli`
- `go test ./...`
- `go test ./... -count=1`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the CLI help output to show a clearer multi-line **Commands** section instead of a single-line usage message.
  * The displayed commands now include server, client, client configuration generation, and version options.
  * Added test coverage to ensure the usage screen continues to list the supported commands correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->