### PR TITLE
Fix plain version tags

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -90,7 +90,7 @@ jobs:
     needs: [run-tests, cross-compile-tests]
     if: github.event_name == 'push' # Prevents this job from running in PR. It will only run on push to main.
     outputs:
-      semver: ${{ steps.gitversion.outputs.semVer }}
+      semver: ${{ steps.gitversion.outputs.majorMinorPatch }}
     steps:
       - name: Get repository code
         uses: actions/checkout@v7.0.0
@@ -111,5 +111,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          git tag $(echo ${{ steps.gitversion.outputs.semVer }})
-          git push origin $(echo ${{ steps.gitversion.outputs.semVer }})
+          VERSION="${{ steps.gitversion.outputs.majorMinorPatch }}"
+          git tag "$VERSION"
+          git push origin "$VERSION"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -115,5 +115,4 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           VERSION="${{ steps.gitversion.outputs.majorMinorPatch }}"
-          git tag "$VERSION"
-          git push origin "$VERSION"
+          git push origin "HEAD:refs/tags/$VERSION"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -89,6 +89,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: [run-tests, cross-compile-tests]
     if: github.event_name == 'push' # Prevents this job from running in PR. It will only run on push to main.
+    concurrency:
+      group: ${{ github.workflow }}-version-and-tag-${{ github.ref }}
+      cancel-in-progress: false
     outputs:
       semver: ${{ steps.gitversion.outputs.majorMinorPatch }}
     steps:


### PR DESCRIPTION
## Summary

- Tag releases from GitVersion's `majorMinorPatch` output instead of `semVer`.
- Keep the `version-and-tag` job output aligned with the plain release tag.

## Why

After upgrading GitVersion, `semVer` can include a commit-distance suffix such as `0.3.22-11` in continuous delivery mode. The project expects plain release tags like `0.3.22`, matching the previous release format.

## Validation

- `git diff --cached --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the release workflow to generate tags using a more consistent, workflow-derived version value.
  * Improved run coordination for the versioning/tagging job to prevent unintended overlapping executions.
  * Adjusted the exported version output used by the tagging step to better align the version reported with the tag pushed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->