### PR TITLE
perf(rekey): avoid locks in steady-state packet path

### DIFF
--- a/src/internal/protocol/chacha20/rekey/state_machine.go
+++ b/src/internal/protocol/chacha20/rekey/state_machine.go
@@ -3,6 +3,7 @@ package rekey
 import (
 	"fmt"
 	"sync"
+	"sync/atomic"
 	"tungo/internal/protocol/securemem"
 
 	"golang.org/x/crypto/chacha20poly1305"
@@ -23,13 +24,11 @@ type EpochManager interface {
 type keys struct {
 	c2s   []byte
 	s2c   []byte
-	epoch uint16
+	epoch atomic.Uint32
 }
 
-type transitionPhase uint8
-
 const (
-	phaseIdle transitionPhase = iota
+	phaseIdle uint32 = iota
 	phaseStaged
 	phaseRetiring
 )
@@ -37,8 +36,8 @@ const (
 type state struct {
 	current              keys
 	staged               keys
-	maxObservedPeerEpoch uint16
-	phase                transitionPhase
+	maxObservedPeerEpoch atomic.Uint32
+	phase                atomic.Uint32
 }
 
 // StateMachine holds canonical control-plane keys and coordinates epoch lifecycle.
@@ -81,7 +80,7 @@ func (c *StateMachine) CurrentKeys() (clientToServer, serverToClient []byte) {
 func (c *StateMachine) ReadyForRekey() bool {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	return c.state.phase == phaseIdle
+	return c.state.phase.Load() == phaseIdle
 }
 
 // SendEpoch returns the epoch currently used for outbound packets. Control-plane
@@ -89,7 +88,7 @@ func (c *StateMachine) ReadyForRekey() bool {
 func (c *StateMachine) SendEpoch() uint16 {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	return c.state.current.epoch
+	return uint16(c.state.current.epoch.Load())
 }
 
 // StartRekey performs an atomic control-plane update:
@@ -108,7 +107,7 @@ func (c *StateMachine) StartRekey(c2s, s2c []byte) (uint16, error) {
 			chacha20poly1305.KeySize,
 		)
 	}
-	if c.state.phase != phaseIdle {
+	if c.state.phase.Load() != phaseIdle {
 		return 0, fmt.Errorf("rekey already in progress")
 	}
 	staged := &c.state.staged
@@ -118,8 +117,8 @@ func (c *StateMachine) StartRekey(c2s, s2c []byte) (uint16, error) {
 	}
 	copy(staged.c2s, c2s)
 	copy(staged.s2c, s2c)
-	staged.epoch = epoch
-	c.state.phase = phaseStaged
+	staged.epoch.Store(uint32(epoch))
+	c.state.phase.Store(phaseStaged)
 	return epoch, nil
 }
 
@@ -127,22 +126,24 @@ func (c *StateMachine) StartRekey(c2s, s2c []byte) (uint16, error) {
 // The caller owns the protocol decision to activate; authenticated inbound
 // observations are reported separately through ObservePeerEpoch.
 func (c *StateMachine) ActivateSendEpoch(epoch uint16) {
+	if uint16(c.state.current.epoch.Load()) >= epoch {
+		return
+	}
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	if !c.activateStagedLocked(epoch) {
 		return
 	}
-	c.epochManager.PromoteSendEpoch(epoch)
 	c.retirePreviousEpochLocked()
 }
 
 func (c *StateMachine) retirePreviousEpochLocked() {
 	state := &c.state
-	if state.phase != phaseRetiring || state.maxObservedPeerEpoch < state.current.epoch {
+	if state.phase.Load() != phaseRetiring || state.maxObservedPeerEpoch.Load() < state.current.epoch.Load() {
 		return
 	}
 	if c.epochManager.RetirePreviousEpoch() {
-		state.phase = phaseIdle
+		state.phase.Store(phaseIdle)
 	}
 }
 
@@ -150,19 +151,35 @@ func (c *StateMachine) retirePreviousEpochLocked() {
 // authenticated. Once local send and peer receive have both moved forward,
 // the previous epoch can be retired by the crypto implementation.
 func (c *StateMachine) ObservePeerEpoch(epoch uint16) {
+	u32Epoch := uint32(epoch)
+	if c.state.maxObservedPeerEpoch.Load() >= u32Epoch &&
+		c.state.phase.Load() != phaseRetiring {
+		return
+	}
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	c.state.maxObservedPeerEpoch = max(c.state.maxObservedPeerEpoch, epoch)
+	if c.state.maxObservedPeerEpoch.Load() < u32Epoch {
+		c.state.maxObservedPeerEpoch.Store(u32Epoch)
+	}
 	c.retirePreviousEpochLocked()
 }
 
 func (c *StateMachine) activateStagedLocked(epoch uint16) bool {
-	if c.state.phase != phaseStaged || epoch != c.state.staged.epoch {
+	if c.state.phase.Load() != phaseStaged || epoch != uint16(c.state.staged.epoch.Load()) {
 		return false
 	}
-	c.state.current, c.state.staged = c.state.staged, c.state.current
+	c.epochManager.PromoteSendEpoch(epoch)
+	stagedEpoch := c.state.staged.epoch.Load()
+	oldCurrentEpoch := c.state.current.epoch.Swap(stagedEpoch)
+	c.state.staged.epoch.Store(oldCurrentEpoch)
+
+	c.state.current.c2s, c.state.staged.c2s =
+		c.state.staged.c2s, c.state.current.c2s
+	c.state.current.s2c, c.state.staged.s2c =
+		c.state.staged.s2c, c.state.current.s2c
+
 	c.clearStagedLocked()
-	c.state.phase = phaseRetiring
+	c.state.phase.Store(phaseRetiring)
 	return true
 }
 

--- a/src/internal/protocol/chacha20/rekey/state_machine_test.go
+++ b/src/internal/protocol/chacha20/rekey/state_machine_test.go
@@ -125,8 +125,8 @@ func TestNewStateMachine_InitialStateAndKeyCopies(t *testing.T) {
 	if !sm.ReadyForRekey() {
 		t.Fatal("expected a new state machine to be ready for rekey")
 	}
-	if sm.state.current.epoch != 0 {
-		t.Fatalf("expected sendEpoch=0, got %d", sm.state.current.epoch)
+	if got := sm.state.current.epoch.Load(); got != 0 {
+		t.Fatalf("expected sendEpoch=0, got %d", got)
 	}
 
 	// Ensure keys are copied on construction.
@@ -156,16 +156,16 @@ func TestStartRekey_StagesEpochAndDoesNotSwitchSendUntilAck(t *testing.T) {
 	if sm.ReadyForRekey() {
 		t.Fatal("expected staged epoch to block another rekey")
 	}
-	if sm.state.staged.epoch != 10 {
-		t.Fatalf("expected staged epoch=10, got %+v", sm.state.staged)
+	if got := sm.state.staged.epoch.Load(); got != 10 {
+		t.Fatalf("expected staged epoch=10, got %d", got)
 	}
-	if sm.state.phase != phaseStaged {
-		t.Fatalf("expected staged phase, got %v", sm.state.phase)
+	if got := sm.state.phase.Load(); got != phaseStaged {
+		t.Fatalf("expected staged phase, got %v", got)
 	}
 
 	// Must not switch send epoch until confirmed.
-	if sm.state.current.epoch != 0 {
-		t.Fatalf("expected sendEpoch still 0, got %d", sm.state.current.epoch)
+	if got := sm.state.current.epoch.Load(); got != 0 {
+		t.Fatalf("expected sendEpoch still 0, got %d", got)
 	}
 
 	_, _, _, setCalls := mock.Snapshot()
@@ -188,8 +188,10 @@ func TestStartRekey_RejectsInvalidKeySize(t *testing.T) {
 			if installCalls != 0 {
 				t.Fatalf("expected StageEpoch not to be called, got %d calls", installCalls)
 			}
-			if !sm.ReadyForRekey() || sm.state.phase != phaseIdle {
-				t.Fatalf("expected idle machine, got %+v", sm.state)
+			ready := sm.ReadyForRekey()
+			phase := sm.state.phase.Load()
+			if !ready || phase != phaseIdle {
+				t.Fatalf("expected idle machine: ready=%t phase=%d", ready, phase)
 			}
 		})
 	}
@@ -232,11 +234,11 @@ func TestActivateSendEpoch_PromotesKeysAndWaitsForPeerObservation(t *testing.T) 
 
 	sm.ActivateSendEpoch(epoch)
 
-	if sm.state.current.epoch != epoch {
-		t.Fatalf("expected sendEpoch=%d, got %d", epoch, sm.state.current.epoch)
+	if got := sm.state.current.epoch.Load(); got != uint32(epoch) {
+		t.Fatalf("expected sendEpoch=%d, got %d", epoch, got)
 	}
-	if sm.state.phase != phaseRetiring {
-		t.Fatalf("expected retiring phase, got %v", sm.state.phase)
+	if got := sm.state.phase.Load(); got != phaseRetiring {
+		t.Fatalf("expected retiring phase, got %v", got)
 	}
 	if sm.ReadyForRekey() {
 		t.Fatal("expected previous epoch retirement to block another rekey")
@@ -277,8 +279,8 @@ func TestActivateSendEpoch_DoesNotActivateIfEpochNotConfirmed(t *testing.T) {
 	if sm.ReadyForRekey() {
 		t.Fatal("expected staged epoch to remain")
 	}
-	if sm.state.current.epoch != 0 {
-		t.Fatalf("expected sendEpoch still 0, got %d", sm.state.current.epoch)
+	if got := sm.state.current.epoch.Load(); got != 0 {
+		t.Fatalf("expected sendEpoch still 0, got %d", got)
 	}
 
 	_, _, _, setCalls := mock.Snapshot()
@@ -339,11 +341,11 @@ func TestActivateSendEpoch_WaitsForRekeyAndActivatesStaged(t *testing.T) {
 	if startEpoch != 42 {
 		t.Fatalf("expected epoch=42, got %d", startEpoch)
 	}
-	if sm.state.current.epoch != 42 {
-		t.Fatalf("expected sendEpoch=42, got %d", sm.state.current.epoch)
+	if got := sm.state.current.epoch.Load(); got != 42 {
+		t.Fatalf("expected sendEpoch=42, got %d", got)
 	}
-	if sm.state.phase != phaseRetiring {
-		t.Fatalf("expected retiring phase, got %v", sm.state.phase)
+	if got := sm.state.phase.Load(); got != phaseRetiring {
+		t.Fatalf("expected retiring phase, got %v", got)
 	}
 	gotC2S, gotS2C := sm.CurrentKeys()
 	if !reflect.DeepEqual(gotC2S, stateMachineTestKey("new-c2s")) ||
@@ -404,8 +406,10 @@ func TestStartRekey_ConcurrentCallWaitsThenFailsWhenStaged(t *testing.T) {
 		t.Fatalf("timeout waiting for second StartRekey to finish")
 	}
 
-	if sm.ReadyForRekey() || sm.state.phase != phaseStaged {
-		t.Fatalf("expected first epoch to remain staged, got %+v", sm.state)
+	ready := sm.ReadyForRekey()
+	phase := sm.state.phase.Load()
+	if ready || phase != phaseStaged {
+		t.Fatalf("expected first epoch to remain staged: ready=%t phase=%d", ready, phase)
 	}
 }
 
@@ -463,8 +467,8 @@ func TestObservePeerEpoch_TracksMaxAuthenticatedEpoch(t *testing.T) {
 	sm.ObservePeerEpoch(7)
 	sm.ObservePeerEpoch(11)
 
-	if sm.state.maxObservedPeerEpoch != 11 {
-		t.Fatalf("expected maxObservedPeerEpoch=11, got %d", sm.state.maxObservedPeerEpoch)
+	if got := sm.state.maxObservedPeerEpoch.Load(); got != 11 {
+		t.Fatalf("expected maxObservedPeerEpoch=11, got %d", got)
 	}
 }
 
@@ -477,8 +481,16 @@ func TestObservePeerEpoch_DoesNotActivateStagedEpoch(t *testing.T) {
 
 	sm.ObservePeerEpoch(4)
 
-	if sm.state.current.epoch != 0 || sm.state.phase != phaseStaged || sm.state.staged.epoch != 4 {
-		t.Fatalf("observation must not activate send: send=%d staged=%+v", sm.state.current.epoch, sm.state.staged)
+	currentEpoch := sm.state.current.epoch.Load()
+	phase := sm.state.phase.Load()
+	stagedEpoch := sm.state.staged.epoch.Load()
+	if currentEpoch != 0 || phase != phaseStaged || stagedEpoch != 4 {
+		t.Fatalf(
+			"observation must not activate send: current=%d staged=%d phase=%d",
+			currentEpoch,
+			stagedEpoch,
+			phase,
+		)
 	}
 	if sm.ReadyForRekey() {
 		t.Fatal("expected staged epoch to block another rekey")
@@ -506,8 +518,8 @@ func TestEpochRetiresAfterSendActivationAndPeerObservation(t *testing.T) {
 	if calls := mock.RetireCalls(); calls != 1 {
 		t.Fatalf("expected one RetirePreviousEpoch call, got %d", calls)
 	}
-	if sm.state.phase != phaseIdle {
-		t.Fatalf("expected completed retirement to be cleared, got %+v", sm.state)
+	if got := sm.state.phase.Load(); got != phaseIdle {
+		t.Fatalf("expected completed retirement to be cleared, got phase=%d", got)
 	}
 }
 
@@ -572,7 +584,7 @@ func TestEpochRetirementRetriesAfterCryptoRefusal(t *testing.T) {
 	}
 	sm.ActivateSendEpoch(epoch)
 	sm.ObservePeerEpoch(epoch)
-	if sm.state.phase != phaseRetiring {
+	if sm.state.phase.Load() != phaseRetiring {
 		t.Fatal("expected refused retirement to remain pending")
 	}
 
@@ -581,8 +593,8 @@ func TestEpochRetirementRetriesAfterCryptoRefusal(t *testing.T) {
 	mock.mu.Unlock()
 	sm.ObservePeerEpoch(epoch)
 
-	if sm.state.phase != phaseIdle {
-		t.Fatalf("expected retirement to clear after retry, got %+v", sm.state)
+	if got := sm.state.phase.Load(); got != phaseIdle {
+		t.Fatalf("expected retirement to clear after retry, got phase=%d", got)
 	}
 	if calls := mock.RetireCalls(); calls != 2 {
 		t.Fatalf("expected two retirement attempts, got %d", calls)


### PR DESCRIPTION
## Summary

- add atomic fast paths for authenticated peer-epoch observation and send-epoch activation
- keep mutex serialization for actual rekey transitions and control-plane snapshots
- preserve observation-before-activation and retirement-retry behavior
- update state-machine tests for atomic state fields

## Validation

- go test -count=1 ./...
- go test -race -count=1 ./internal/protocol/chacha20/rekey
- go vet ./internal/protocol/chacha20/rekey
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved rekey state handling for concurrent operations.
  * Prevented unnecessary epoch transitions and ensured peer epoch observations advance correctly.
  * Preserved existing behavior for staging, activation, retirement, retries, invalid inputs, and concurrent scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->