### PR TITLE
fix(udp-client): decouple liveness checks from reads

### DIFF
--- a/src/internal/client/udp/activity_tracker.go
+++ b/src/internal/client/udp/activity_tracker.go
@@ -1,0 +1,27 @@
+package udp
+
+import (
+	"sync/atomic"
+	"time"
+)
+
+type activityTracker struct {
+	startedAt     time.Time
+	lastElapsedMs atomic.Int64
+}
+
+func newActivityTracker() *activityTracker {
+	return &activityTracker{
+		startedAt: time.Now(),
+	}
+}
+
+func (m *activityTracker) Touch() {
+	m.lastElapsedMs.Store(time.Since(m.startedAt).Milliseconds())
+}
+
+func (m *activityTracker) IdleFor() time.Duration {
+	last := m.lastElapsedMs.Load()
+	now := time.Since(m.startedAt).Milliseconds()
+	return time.Duration(now-last) * time.Millisecond
+}

--- a/src/internal/client/udp/activity_tracker_test.go
+++ b/src/internal/client/udp/activity_tracker_test.go
@@ -1,0 +1,76 @@
+package udp
+
+import (
+	"sync"
+	"testing"
+	"time"
+)
+
+func setActivityTrackerIdleFor(tracker *activityTracker, idleFor time.Duration) {
+	elapsedMs := time.Since(tracker.startedAt).Milliseconds()
+	tracker.lastElapsedMs.Store(elapsedMs - idleFor.Milliseconds())
+}
+
+func TestActivityTrackerStartsAtCreation(t *testing.T) {
+	tracker := newActivityTracker()
+
+	idleFor := tracker.IdleFor()
+	if idleFor < 0 || idleFor >= time.Minute {
+		t.Fatalf("IdleFor() = %s, want duration since tracker creation", idleFor)
+	}
+}
+
+func TestActivityTrackerTouchResetsIdleTime(t *testing.T) {
+	tracker := newActivityTracker()
+	const previousIdleTime = 1500 * time.Millisecond
+	setActivityTrackerIdleFor(tracker, previousIdleTime)
+
+	if idleFor := tracker.IdleFor(); idleFor < previousIdleTime {
+		t.Fatalf("IdleFor() before Touch() = %s, want at least %s", idleFor, previousIdleTime)
+	}
+
+	tracker.Touch()
+	if idleFor := tracker.IdleFor(); idleFor < 0 || idleFor >= time.Second {
+		t.Fatalf("IdleFor() after Touch() = %s, want less than 1s", idleFor)
+	}
+}
+
+func TestActivityTrackerConcurrentTouchAndIdleFor(t *testing.T) {
+	tracker := newActivityTracker()
+	start := make(chan struct{})
+	negativeIdle := make(chan time.Duration, 1)
+
+	const (
+		workers    = 8
+		iterations = 1000
+	)
+	var wg sync.WaitGroup
+	wg.Add(workers)
+	for worker := range workers {
+		go func() {
+			defer wg.Done()
+			<-start
+			for range iterations {
+				if worker%2 == 0 {
+					tracker.Touch()
+					continue
+				}
+				if idleFor := tracker.IdleFor(); idleFor < 0 {
+					select {
+					case negativeIdle <- idleFor:
+					default:
+					}
+				}
+			}
+		}()
+	}
+
+	close(start)
+	wg.Wait()
+
+	select {
+	case idleFor := <-negativeIdle:
+		t.Fatalf("IdleFor() = %s during concurrent access, want non-negative duration", idleFor)
+	default:
+	}
+}

--- a/src/internal/client/udp/client.go
+++ b/src/internal/client/udp/client.go
@@ -32,6 +32,11 @@ type Client struct {
 	transport *transportHandler
 }
 
+const (
+	livenessCheckInterval = time.Second
+	writeDeadline         = time.Second
+)
+
 // New builds the complete client UDP packet loop.
 func New(
 	ctx context.Context,
@@ -46,8 +51,7 @@ func New(
 		return nil, err
 	}
 
-	const deadline = time.Second
-	udpTransport := udptransport.NewClientConn(udpConn, deadline, deadline)
+	udpTransport := udptransport.NewClientConn(udpConn, writeDeadline)
 	outbound := newPacketSender(udpTransport, crypto)
 	tunHandler := newTunHandler(ctx, tun, outbound, rekey, allowedSources)
 	transportHandler := newTransportHandler(ctx, udpTransport, tun, crypto, rekey, outbound)
@@ -66,11 +70,20 @@ func (c *Client) Run() error {
 	go func() { errCh <- c.tun.HandleTun() }()
 	go func() { errCh <- c.transport.HandleTransport() }()
 
-	select {
-	case <-c.ctx.Done():
-		return c.ctx.Err()
-	case err := <-errCh:
-		return err
+	t := time.NewTicker(livenessCheckInterval)
+	defer t.Stop()
+
+	for {
+		select {
+		case <-c.ctx.Done():
+			return c.ctx.Err()
+		case err := <-errCh:
+			return err
+		case <-t.C:
+			if err := c.transport.checkLiveness(); err != nil {
+				return err
+			}
+		}
 	}
 }
 

--- a/src/internal/client/udp/client_test.go
+++ b/src/internal/client/udp/client_test.go
@@ -1,0 +1,80 @@
+package udp
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"tungo/internal/config/settings"
+)
+
+func newBlockingTestClient(lastRecvAt time.Time) (*Client, context.CancelFunc) {
+	ctx, cancel := context.WithCancel(context.Background())
+	blockedRead := func([]byte) (int, error) {
+		<-ctx.Done()
+		return 0, ctx.Err()
+	}
+
+	tun := newTunHandler(
+		ctx,
+		&fakeReader{readFunc: blockedRead},
+		nil,
+		nil,
+		nil,
+	)
+	transport := newTransportHandler(
+		ctx,
+		&fakeReader{readFunc: blockedRead},
+		&fakeWriter{},
+		&thTestCrypto{},
+		nil,
+		nil,
+	)
+	transport.lastRecvAt = lastRecvAt
+
+	return &Client{ctx: ctx, tun: tun, transport: transport}, cancel
+}
+
+func TestClientRun_ChecksLivenessWhileReadsAreBlocked(t *testing.T) {
+	t.Parallel()
+
+	client, cancel := newBlockingTestClient(
+		time.Now().Add(-settings.PingRestartTimeout - time.Second),
+	)
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() { done <- client.Run() }()
+
+	select {
+	case err := <-done:
+		if err == nil || !strings.Contains(err.Error(), "server unreachable") {
+			t.Fatalf("Run() error = %v, want server unreachable", err)
+		}
+	case <-time.After(3 * livenessCheckInterval):
+		t.Fatal("Run did not check liveness while reads were blocked")
+	}
+}
+
+func TestClientRun_ContinuesAfterHealthyLivenessTick(t *testing.T) {
+	t.Parallel()
+
+	client, cancel := newBlockingTestClient(time.Now())
+	done := make(chan error, 1)
+	go func() { done <- client.Run() }()
+
+	select {
+	case err := <-done:
+		cancel()
+		t.Fatalf("Run returned after a healthy liveness tick: %v", err)
+	case <-time.After(livenessCheckInterval + 100*time.Millisecond):
+	}
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("Run did not stop after context cancellation")
+	}
+}

--- a/src/internal/client/udp/client_test.go
+++ b/src/internal/client/udp/client_test.go
@@ -9,7 +9,7 @@ import (
 	"tungo/internal/config/settings"
 )
 
-func newBlockingTestClient(lastRecvAt time.Time) (*Client, context.CancelFunc) {
+func newBlockingTestClient(readIdleFor time.Duration) (*Client, context.CancelFunc) {
 	ctx, cancel := context.WithCancel(context.Background())
 	blockedRead := func([]byte) (int, error) {
 		<-ctx.Done()
@@ -31,7 +31,7 @@ func newBlockingTestClient(lastRecvAt time.Time) (*Client, context.CancelFunc) {
 		nil,
 		nil,
 	)
-	transport.lastRecvAt = lastRecvAt
+	setActivityTrackerIdleFor(transport.readActivity, readIdleFor)
 
 	return &Client{ctx: ctx, tun: tun, transport: transport}, cancel
 }
@@ -39,9 +39,7 @@ func newBlockingTestClient(lastRecvAt time.Time) (*Client, context.CancelFunc) {
 func TestClientRun_ChecksLivenessWhileReadsAreBlocked(t *testing.T) {
 	t.Parallel()
 
-	client, cancel := newBlockingTestClient(
-		time.Now().Add(-settings.PingRestartTimeout - time.Second),
-	)
+	client, cancel := newBlockingTestClient(settings.PingRestartTimeout + time.Second)
 	defer cancel()
 
 	done := make(chan error, 1)
@@ -60,7 +58,7 @@ func TestClientRun_ChecksLivenessWhileReadsAreBlocked(t *testing.T) {
 func TestClientRun_ContinuesAfterHealthyLivenessTick(t *testing.T) {
 	t.Parallel()
 
-	client, cancel := newBlockingTestClient(time.Now())
+	client, cancel := newBlockingTestClient(0)
 	done := make(chan error, 1)
 	go func() { done <- client.Run() }()
 

--- a/src/internal/client/udp/transport.go
+++ b/src/internal/client/udp/transport.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
-	"os"
 	"time"
 
 	"tungo/internal/config/settings"
@@ -67,12 +66,6 @@ func (t *transportHandler) HandleTransport() error {
 		default:
 			n, readErr := t.reader.Read(buffer[:])
 			if readErr != nil {
-				if errors.Is(readErr, os.ErrDeadlineExceeded) {
-					if err := t.checkLiveness(); err != nil {
-						return err
-					}
-					continue
-				}
 				if t.ctx.Err() != nil {
 					return nil
 				}

--- a/src/internal/client/udp/transport.go
+++ b/src/internal/client/udp/transport.go
@@ -30,9 +30,9 @@ type transportHandler struct {
 	cryptographyService crypto
 	rekey               transportRekey
 	egress              sender
-	lastRecvAt          time.Time
 	lastPingSentAt      time.Time
 	pingBuf             []byte
+	readActivity        *activityTracker
 }
 
 func newTransportHandler(
@@ -51,8 +51,8 @@ func newTransportHandler(
 		cryptographyService: cryptographyService,
 		rekey:               rekey,
 		egress:              egress,
-		lastRecvAt:          time.Now(),
 		pingBuf:             make([]byte, pingLen, pingLen+chacha20poly1305.Overhead),
+		readActivity:        newActivityTracker(),
 	}
 }
 
@@ -91,7 +91,7 @@ func (t *transportHandler) handleDatagram(pkt []byte) (int, error) {
 		// This makes client resilient to packet corruption and garbage injection.
 		return 0, nil
 	}
-	t.lastRecvAt = time.Now()
+	t.readActivity.Touch()
 	var carrierEpoch uint16
 	if len(pkt) >= udp.EpochOffset+2 {
 		carrierEpoch = binary.BigEndian.Uint16(pkt[udp.EpochOffset : udp.EpochOffset+2])
@@ -153,10 +153,13 @@ func (t *transportHandler) handleControlplane(
 }
 
 func (t *transportHandler) checkLiveness() error {
-	if time.Since(t.lastRecvAt) > settings.PingRestartTimeout {
+	idleFor := t.readActivity.IdleFor()
+	if idleFor > settings.PingRestartTimeout {
 		return fmt.Errorf("server unreachable (no data for %s)", settings.PingRestartTimeout)
 	}
-	if t.egress != nil && time.Since(t.lastPingSentAt) > settings.PingInterval {
+	if t.egress != nil &&
+		idleFor > settings.PingInterval &&
+		time.Since(t.lastPingSentAt) > settings.PingInterval {
 		t.sendPing()
 	}
 	return nil

--- a/src/internal/client/udp/transport_test.go
+++ b/src/internal/client/udp/transport_test.go
@@ -552,8 +552,7 @@ func TestCheckLiveness_PingRestartTimeout(t *testing.T) {
 	ctrl := rekey.NewStateMachine(dummyEpochManager{}, []byte("c2s"), []byte("s2c"))
 	eg := &capturingEgress{}
 	h := newTestTransportHandler(context.Background(), &thTestReader{}, &thTestWriter{}, &thTestCrypto{}, ctrl, nil, eg)
-	// Set lastRecvAt far in the past to trigger timeout immediately.
-	h.lastRecvAt = time.Now().Add(-settings.PingRestartTimeout - time.Second)
+	setActivityTrackerIdleFor(h.readActivity, settings.PingRestartTimeout+time.Second)
 
 	err := h.checkLiveness()
 	if err == nil {
@@ -568,8 +567,7 @@ func TestCheckLiveness_PingSentOnIdle(t *testing.T) {
 	ctrl := rekey.NewStateMachine(dummyEpochManager{}, []byte("c2s"), []byte("s2c"))
 	eg := &capturingEgress{}
 	h := newTestTransportHandler(context.Background(), &thTestReader{}, &thTestWriter{}, &thTestCrypto{}, ctrl, nil, eg)
-	// Set lastRecvAt so that PingInterval is exceeded but PingRestartTimeout is not.
-	h.lastRecvAt = time.Now().Add(-settings.PingInterval - time.Second)
+	setActivityTrackerIdleFor(h.readActivity, settings.PingInterval+time.Second)
 	if err := h.checkLiveness(); err != nil {
 		t.Fatalf("checkLiveness() error = %v", err)
 	}
@@ -589,6 +587,20 @@ func TestCheckLiveness_PingSentOnIdle(t *testing.T) {
 	}
 }
 
+func TestCheckLiveness_DoesNotPingWhileActive(t *testing.T) {
+	eg := &capturingEgress{}
+	h := newTestTransportHandler(context.Background(), nil, nil, nil, nil, nil, eg)
+	h.lastPingSentAt = time.Now().Add(-settings.PingInterval - time.Second)
+	h.readActivity.Touch()
+
+	if err := h.checkLiveness(); err != nil {
+		t.Fatalf("checkLiveness() error = %v", err)
+	}
+	if packets := eg.Packets(); len(packets) != 0 {
+		t.Fatalf("sent %d Ping packets while connection was active, want none", len(packets))
+	}
+}
+
 func TestHandleDatagram_AuthenticatedPacketResetsLiveness(t *testing.T) {
 	encrypted := []byte{0, 42}
 	decrypted := []byte{100}
@@ -596,13 +608,26 @@ func TestHandleDatagram_AuthenticatedPacketResetsLiveness(t *testing.T) {
 	crypto := &thTestCrypto{output: decrypted}
 	ctrl := rekey.NewStateMachine(dummyEpochManager{}, []byte("c2s"), []byte("s2c"))
 	h := newTestTransportHandler(context.Background(), &thTestReader{}, w, crypto, ctrl, nil, nil)
-	h.lastRecvAt = time.Now().Add(-settings.PingRestartTimeout - time.Second)
+	setActivityTrackerIdleFor(h.readActivity, settings.PingRestartTimeout+time.Second)
 
 	if _, err := h.handleDatagram(encrypted); err != nil {
 		t.Fatalf("handleDatagram() error = %v", err)
 	}
 	if err := h.checkLiveness(); err != nil {
 		t.Fatalf("authenticated packet did not reset liveness: %v", err)
+	}
+}
+
+func TestHandleDatagram_DecryptErrorDoesNotResetLiveness(t *testing.T) {
+	crypto := &thTestCrypto{err: errors.New("decrypt failed")}
+	h := newTestTransportHandler(context.Background(), nil, nil, crypto, nil, nil, nil)
+	setActivityTrackerIdleFor(h.readActivity, settings.PingRestartTimeout+time.Second)
+
+	if _, err := h.handleDatagram([]byte{0, 42}); err != nil {
+		t.Fatalf("handleDatagram() error = %v", err)
+	}
+	if err := h.checkLiveness(); err == nil {
+		t.Fatal("decrypt error reset liveness, want server unreachable error")
 	}
 }
 
@@ -672,8 +697,7 @@ func TestCheckLiveness_NilEgress_NoIdlePing(t *testing.T) {
 	// With nil egress, idle should not attempt to send Ping.
 	ctrl := rekey.NewStateMachine(dummyEpochManager{}, []byte("c2s"), []byte("s2c"))
 	h := newTestTransportHandler(context.Background(), &thTestReader{}, &thTestWriter{}, &thTestCrypto{}, ctrl, nil, nil)
-	// Set lastRecvAt so PingInterval is exceeded but not PingRestartTimeout.
-	h.lastRecvAt = time.Now().Add(-settings.PingInterval - time.Second)
+	setActivityTrackerIdleFor(h.readActivity, settings.PingInterval+time.Second)
 
 	if err := h.checkLiveness(); err != nil {
 		t.Fatalf("checkLiveness() error = %v", err)
@@ -740,7 +764,7 @@ func TestCheckLiveness_PingSendError_Swallowed(t *testing.T) {
 	ctrl := rekey.NewStateMachine(dummyEpochManager{}, []byte("c2s"), []byte("s2c"))
 	eg := &capturingEgress{sendErr: errors.New("send failed")}
 	h := newTestTransportHandler(context.Background(), &thTestReader{}, &thTestWriter{}, &thTestCrypto{}, ctrl, nil, eg)
-	h.lastRecvAt = time.Now().Add(-settings.PingInterval - time.Second)
+	setActivityTrackerIdleFor(h.readActivity, settings.PingInterval+time.Second)
 
 	if err := h.checkLiveness(); err != nil {
 		t.Fatalf("checkLiveness() error = %v", err)

--- a/src/internal/client/udp/transport_test.go
+++ b/src/internal/client/udp/transport_test.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"os"
 	"strings"
 	"sync"
 	"testing"
@@ -238,28 +237,6 @@ func TestHandleTransport_ReadErrorOther(t *testing.T) {
 	exp := fmt.Sprintf("could not read a packet from adapter: %v", errRead)
 	if err := h.HandleTransport(); err == nil || err.Error() != exp {
 		t.Errorf("expected %q, got %v", exp, err)
-	}
-}
-
-func TestHandleTransport_ReadDeadlineExceededSkip(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	r := &thTestReader{reads: []func(p []byte) (int, error){
-		func(p []byte) (int, error) { return 0, os.ErrDeadlineExceeded },
-		func(p []byte) (int, error) { <-ctx.Done(); return 0, errors.New("stop") },
-	}}
-	w := &thTestWriter{}
-	ctrl := rekey.NewStateMachine(dummyEpochManager{}, []byte("c2s"), []byte("s2c"))
-	h := newTestTransportHandler(ctx, r, w, &thTestCrypto{}, ctrl, nil, nil)
-
-	done := make(chan error)
-	go func() { done <- h.HandleTransport() }()
-
-	time.Sleep(10 * time.Millisecond)
-	cancel()
-	if err := <-done; err != nil {
-		t.Errorf("expected nil after skip and cancel, got %v", err)
 	}
 }
 
@@ -571,24 +548,14 @@ func (e *capturingEgress) Packets() [][]byte {
 	return out
 }
 
-func TestHandleTransport_PingRestartTimeout(t *testing.T) {
-	// Reader returns only deadline-exceeded errors; after PingRestartTimeout
-	// the handler must return an error indicating unreachable server.
-	r := &thTestReader{reads: make([]func(p []byte) (int, error), 0)}
-	// Fill enough reads to outlast the timeout. Each deadline-exceeded wakes ~immediately in test.
-	for i := 0; i < 200; i++ {
-		r.reads = append(r.reads, func(p []byte) (int, error) {
-			return 0, os.ErrDeadlineExceeded
-		})
-	}
-	w := &thTestWriter{}
+func TestCheckLiveness_PingRestartTimeout(t *testing.T) {
 	ctrl := rekey.NewStateMachine(dummyEpochManager{}, []byte("c2s"), []byte("s2c"))
 	eg := &capturingEgress{}
-	h := newTestTransportHandler(context.Background(), r, w, &thTestCrypto{}, ctrl, nil, eg)
+	h := newTestTransportHandler(context.Background(), &thTestReader{}, &thTestWriter{}, &thTestCrypto{}, ctrl, nil, eg)
 	// Set lastRecvAt far in the past to trigger timeout immediately.
 	h.lastRecvAt = time.Now().Add(-settings.PingRestartTimeout - time.Second)
 
-	err := h.HandleTransport()
+	err := h.checkLiveness()
 	if err == nil {
 		t.Fatal("expected error for unreachable server, got nil")
 	}
@@ -597,29 +564,15 @@ func TestHandleTransport_PingRestartTimeout(t *testing.T) {
 	}
 }
 
-func TestHandleTransport_PingSentOnIdle(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	// First read: deadline exceeded (triggers Ping send).
-	// Second read: blocks until cancel.
-	r := &thTestReader{reads: []func(p []byte) (int, error){
-		func(p []byte) (int, error) { return 0, os.ErrDeadlineExceeded },
-		func(p []byte) (int, error) { <-ctx.Done(); return 0, errors.New("stop") },
-	}}
-	w := &thTestWriter{}
+func TestCheckLiveness_PingSentOnIdle(t *testing.T) {
 	ctrl := rekey.NewStateMachine(dummyEpochManager{}, []byte("c2s"), []byte("s2c"))
 	eg := &capturingEgress{}
-	h := newTestTransportHandler(ctx, r, w, &thTestCrypto{}, ctrl, nil, eg)
+	h := newTestTransportHandler(context.Background(), &thTestReader{}, &thTestWriter{}, &thTestCrypto{}, ctrl, nil, eg)
 	// Set lastRecvAt so that PingInterval is exceeded but PingRestartTimeout is not.
 	h.lastRecvAt = time.Now().Add(-settings.PingInterval - time.Second)
-
-	done := make(chan error)
-	go func() { done <- h.HandleTransport() }()
-
-	time.Sleep(20 * time.Millisecond)
-	cancel()
-	<-done
+	if err := h.checkLiveness(); err != nil {
+		t.Fatalf("checkLiveness() error = %v", err)
+	}
 
 	pkts := eg.Packets()
 	if len(pkts) == 0 {
@@ -636,36 +589,20 @@ func TestHandleTransport_PingSentOnIdle(t *testing.T) {
 	}
 }
 
-func TestHandleTransport_RecvResetsPingTimer(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	// Sequence:
-	// 1. Read deadline exceeded (idle, but within PingRestartTimeout)
-	// 2. Read data (successful decrypt resets lastRecvAt)
-	// 3. Read deadline exceeded again — should NOT timeout
-	// 4. Block until cancel
+func TestHandleDatagram_AuthenticatedPacketResetsLiveness(t *testing.T) {
 	encrypted := []byte{0, 42}
 	decrypted := []byte{100}
-	r := &thTestReader{reads: []func(p []byte) (int, error){
-		func(p []byte) (int, error) { return 0, os.ErrDeadlineExceeded },
-		func(p []byte) (int, error) { copy(p, encrypted); return len(encrypted), nil },
-		func(p []byte) (int, error) { return 0, os.ErrDeadlineExceeded },
-		func(p []byte) (int, error) { <-ctx.Done(); return 0, errors.New("stop") },
-	}}
 	w := &thTestWriter{}
 	crypto := &thTestCrypto{output: decrypted}
 	ctrl := rekey.NewStateMachine(dummyEpochManager{}, []byte("c2s"), []byte("s2c"))
-	h := newTestTransportHandler(ctx, r, w, crypto, ctrl, nil, nil)
+	h := newTestTransportHandler(context.Background(), &thTestReader{}, w, crypto, ctrl, nil, nil)
+	h.lastRecvAt = time.Now().Add(-settings.PingRestartTimeout - time.Second)
 
-	done := make(chan error)
-	go func() { done <- h.HandleTransport() }()
-
-	time.Sleep(20 * time.Millisecond)
-	cancel()
-	err := <-done
-	if err != nil {
-		t.Fatalf("expected nil (recv should have reset timer), got %v", err)
+	if _, err := h.handleDatagram(encrypted); err != nil {
+		t.Fatalf("handleDatagram() error = %v", err)
+	}
+	if err := h.checkLiveness(); err != nil {
+		t.Fatalf("authenticated packet did not reset liveness: %v", err)
 	}
 }
 
@@ -731,28 +668,15 @@ func TestHandleTransport_EpochExhausted_ReturnsError(t *testing.T) {
 	}
 }
 
-func TestHandleTransport_NilEgress_NoIdlePing(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
+func TestCheckLiveness_NilEgress_NoIdlePing(t *testing.T) {
 	// With nil egress, idle should not attempt to send Ping.
-	r := &thTestReader{reads: []func(p []byte) (int, error){
-		func(p []byte) (int, error) { return 0, os.ErrDeadlineExceeded },
-		func(p []byte) (int, error) { <-ctx.Done(); return 0, errors.New("stop") },
-	}}
-	w := &thTestWriter{}
 	ctrl := rekey.NewStateMachine(dummyEpochManager{}, []byte("c2s"), []byte("s2c"))
-	h := newTestTransportHandler(ctx, r, w, &thTestCrypto{}, ctrl, nil, nil)
+	h := newTestTransportHandler(context.Background(), &thTestReader{}, &thTestWriter{}, &thTestCrypto{}, ctrl, nil, nil)
 	// Set lastRecvAt so PingInterval is exceeded but not PingRestartTimeout.
 	h.lastRecvAt = time.Now().Add(-settings.PingInterval - time.Second)
 
-	done := make(chan error)
-	go func() { done <- h.HandleTransport() }()
-
-	time.Sleep(10 * time.Millisecond)
-	cancel()
-	if err := <-done; err != nil {
-		t.Fatalf("expected nil, got %v", err)
+	if err := h.checkLiveness(); err != nil {
+		t.Fatalf("checkLiveness() error = %v", err)
 	}
 	// No panic = success (nil egress handled gracefully).
 }
@@ -811,28 +735,15 @@ func TestHandleTransport_ShortRekeyAck_IgnoredAndContinues(t *testing.T) {
 	}
 }
 
-func TestHandleTransport_PingSendError_Swallowed(t *testing.T) {
+func TestCheckLiveness_PingSendError_Swallowed(t *testing.T) {
 	// When egress.Send returns an error during Ping, sendPing returns early without panic.
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	r := &thTestReader{reads: []func(p []byte) (int, error){
-		func(p []byte) (int, error) { return 0, os.ErrDeadlineExceeded },
-		func(p []byte) (int, error) { <-ctx.Done(); return 0, errors.New("stop") },
-	}}
-	w := &thTestWriter{}
 	ctrl := rekey.NewStateMachine(dummyEpochManager{}, []byte("c2s"), []byte("s2c"))
 	eg := &capturingEgress{sendErr: errors.New("send failed")}
-	h := newTestTransportHandler(ctx, r, w, &thTestCrypto{}, ctrl, nil, eg)
+	h := newTestTransportHandler(context.Background(), &thTestReader{}, &thTestWriter{}, &thTestCrypto{}, ctrl, nil, eg)
 	h.lastRecvAt = time.Now().Add(-settings.PingInterval - time.Second)
 
-	done := make(chan error)
-	go func() { done <- h.HandleTransport() }()
-
-	time.Sleep(20 * time.Millisecond)
-	cancel()
-	if err := <-done; err != nil {
-		t.Fatalf("expected nil, got %v", err)
+	if err := h.checkLiveness(); err != nil {
+		t.Fatalf("checkLiveness() error = %v", err)
 	}
 }
 

--- a/src/internal/transport/udp/client.go
+++ b/src/internal/transport/udp/client.go
@@ -9,18 +9,17 @@ import (
 
 // clientConn - single goroutine only client UDP adapter
 type clientConn struct {
-	conn                        *net.UDPConn
-	buf                         [settings.DefaultEthernetMTU + settings.UDPChacha20Overhead]byte
-	readDeadline, writeDeadline time.Duration
+	conn          *net.UDPConn
+	buf           [settings.DefaultEthernetMTU + settings.UDPChacha20Overhead]byte
+	writeDeadline time.Duration
 }
 
 func NewClientConn(
 	conn *net.UDPConn,
-	readDeadline, writeDeadline time.Duration) io.ReadWriteCloser {
+	writeDeadline time.Duration) io.ReadWriteCloser {
 	return &clientConn{
 		conn:          conn,
 		writeDeadline: writeDeadline,
-		readDeadline:  readDeadline,
 	}
 }
 
@@ -37,14 +36,6 @@ func (c *clientConn) Write(buffer []byte) (int, error) {
 }
 
 func (c *clientConn) Read(buffer []byte) (int, error) {
-	deadline := time.Time{}
-	if c.readDeadline > 0 {
-		deadline = time.Now().Add(c.readDeadline)
-	}
-	if err := c.conn.SetReadDeadline(deadline); err != nil {
-		return 0, err
-	}
-
 	// Fast path: packet-loop buffers are already max-sized, so read directly
 	// into caller memory and avoid an extra copy.
 	if len(buffer) >= len(c.buf) {

--- a/src/internal/transport/udp/client_test.go
+++ b/src/internal/transport/udp/client_test.go
@@ -23,8 +23,8 @@ func newPair(tb testing.TB) (*clientConn, *net.UDPConn) {
 		tb.Fatalf("dial: %v", err)
 	}
 
-	// 1-second deadlines for tests
-	ad := NewClientConn(client, time.Second, time.Second)
+	// Keep writes bounded; reads are interrupted by closing the connection.
+	ad := NewClientConn(client, time.Second)
 	return ad.(*clientConn), server
 }
 
@@ -88,23 +88,6 @@ func TestWriteAfterClose(t *testing.T) {
 	}
 }
 
-func TestReadTimeout(t *testing.T) {
-	ad, _ := newPair(t)
-	defer func(ad *clientConn) {
-		_ = ad.Close()
-	}(ad)
-
-	ad.readDeadline = 5 * time.Millisecond
-
-	start := time.Now()
-	if _, err := ad.Read(make([]byte, 1)); err == nil {
-		t.Fatalf("expected timeout")
-	}
-	if time.Since(start) < 5*time.Millisecond {
-		t.Fatalf("deadline not respected")
-	}
-}
-
 func TestReadFastPath(t *testing.T) {
 	ad, srv := newPair(t)
 	defer func() { _ = ad.Close() }()
@@ -118,17 +101,6 @@ func TestReadFastPath(t *testing.T) {
 	buffer := make([]byte, len(ad.buf))
 	if n, err := ad.Read(buffer); err != nil || string(buffer[:n]) != string(msg) {
 		t.Fatalf("Read = (%q, %v), want (%q, nil)", buffer[:n], err, msg)
-	}
-}
-
-func TestReadFastPathTimeout(t *testing.T) {
-	ad, srv := newPair(t)
-	defer func() { _ = ad.Close() }()
-	defer func() { _ = srv.Close() }()
-	ad.readDeadline = 5 * time.Millisecond
-
-	if _, err := ad.Read(make([]byte, len(ad.buf))); err == nil {
-		t.Fatal("expected timeout")
 	}
 }
 


### PR DESCRIPTION
## Summary

- stop resetting UDP read deadlines on every packet and run liveness checks independently
- track authenticated read activity with a monotonic atomic tracker
- send keepalive pings only after actual read inactivity
- remove obsolete deadline error handling

## Validation

- go test -count=1 ./...
- go test -race -count=1 ./internal/client/udp
- go vet ./internal/client/udp

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Reliability**
  * Improved UDP connection liveness monitoring while reads are blocked.
  * UDP activity is now tracked more accurately, with authenticated traffic resetting the idle timer.
  * Unresponsive servers are detected through periodic liveness checks.

* **Performance**
  * Streamlined UDP packet reads, including a faster path for sufficiently large buffers.

* **Bug Fixes**
  * Prevented invalid negative idle durations during concurrent activity checks.
  * Improved handling of liveness-check and ping-send failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->